### PR TITLE
Removed gradients during evaluation

### DIFF
--- a/experiments/pad/train.py
+++ b/experiments/pad/train.py
@@ -35,9 +35,10 @@ def eval_one_epoch(config, data_loader, device, model, action_normalizer=None):
         unnormalize = lambda a: a
 
     def decode_and_plot(latents, nrows=4):
-        images = model.obs_encoder.apply_vae(latents, inverse=True)
-        images = rearrange(images, "b v c t h w -> (b v t) c h w")
-        images_grid = make_grid(images, nrows)
+        with torch.no_grad():
+            images = model.obs_encoder.apply_vae(latents, inverse=True)
+            images = rearrange(images, "b v c t h w -> (b v t) c h w")
+            images_grid = make_grid(images, nrows)
         return images_grid
 
     stats = {

--- a/experiments/uwm/train.py
+++ b/experiments/uwm/train.py
@@ -46,9 +46,10 @@ def eval_one_epoch(config, data_loader, device, model, action_normalizer=None):
         unnormalize = lambda a: a
 
     def decode_and_plot(images, nrows=4):
-        images = model.obs_encoder.apply_vae(images, inverse=True)
-        images = rearrange(images, "b v c t h w -> (b v t) c h w")
-        images_grid = make_grid(images, nrows)
+        with torch.no_grad():
+            images = model.obs_encoder.apply_vae(images, inverse=True)
+            images = rearrange(images, "b v c t h w -> (b v t) c h w")
+            images_grid = make_grid(images, nrows)
         return images_grid
 
     stats = {


### PR DESCRIPTION
The decode_and_plot function called during evaluation had gradients attached to the output image, so I added torch.no_grad() to remove them